### PR TITLE
iOS SDK 0.9.15

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ platform :ios, '10.3'
 
 target 'StreemNow' do
   #pod 'Streem', :podspec => '../streem-app/streem-sdk/ios/cocoapods/Streem/0.6.0/Streem.podspec.json'
-  pod 'Streem', '~> 0.8.1'
+  pod 'Streem', '~> 0.9.15'
 
   target 'StreemNow_Tests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,18 +27,18 @@ PODS:
   - RxAnimated/Core (0.4.1):
     - RxCocoa (~> 4.0)
     - RxSwift (~> 4.0)
-  - RxCocoa (4.3.1):
-    - RxSwift (~> 4.0)
-  - RxSwift (4.3.1)
-  - Streem (0.8.1):
+  - RxCocoa (4.5.0):
+    - RxSwift (>= 4.4.2, ~> 4.4)
+  - RxSwift (4.5.0)
+  - Streem (0.9.15):
     - PromiseKit (~> 6.2.8)
     - RxAnimated (~> 0.4.1)
-    - RxCocoa (~> 4.3.0)
-    - RxSwift (~> 4.3.0)
+    - RxCocoa (~> 4.5.0)
+    - RxSwift (~> 4.5.0)
     - SwiftProtobuf (~> 1.0)
     - TwilioSyncClient (~> 0.7.5)
     - TwilioVideo (= 2.6.0)
-  - SwiftProtobuf (1.4.0)
+  - SwiftProtobuf (1.5.0)
   - TwilioSyncClient (0.7.5)
   - TwilioVideo (2.6.0)
 
@@ -47,7 +47,7 @@ DEPENDENCIES:
   - Nimble (~> 7.0.2)
   - Nimble-Snapshots (~> 6.3.0)
   - Quick (~> 1.2.0)
-  - Streem (~> 0.8.1)
+  - Streem (~> 0.9.15)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -73,13 +73,13 @@ SPEC CHECKSUMS:
   PromiseKit: 6788ce1a0ed5448b83d4aaf56b9fc49fb7647d32
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   RxAnimated: 8b3142830a60840ebed5755d33b9c88ad5a1647c
-  RxCocoa: 78763c7b07d02455598d9fc3c1ad091a28b73635
-  RxSwift: fe0fd770a43acdb7d0a53da411c9b892e69bb6e4
-  Streem: 29ffa4c7d2e14216a4b890b5b8f953019bd7ee92
-  SwiftProtobuf: b06646ed6cdcfc3fecd074c6000fe0c413140e4f
+  RxCocoa: cbf70265dc65a981d4ac982e513c10cf23df24a0
+  RxSwift: f172070dfd1a93d70a9ab97a5a01166206e1c575
+  Streem: 7dc2cfd05db2c89009dc0673de2adbae7e977d0a
+  SwiftProtobuf: 241400280f912735c1e1b9fe675fdd2c6c4d42e2
   TwilioSyncClient: 09a90adf4680557747987eccd530b60cf386842a
   TwilioVideo: a3b58b5a7c5a3271b18c8a481a4f0aa51f79b2c4
 
-PODFILE CHECKSUM: 90bde35646b9358ac0beab20b1255d1b94f3efbf
+PODFILE CHECKSUM: 7461a07ee23d9f17368bf9e6b414f0a62f16f60a
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
@seanadkinson up to you whether you'd prefer to go with this, or else roll back our CocoaPods repo to `0.9.0`.