### PR TITLE
expose domain field

### DIFF
--- a/StreemNow/StreemInitializer.swift
+++ b/StreemNow/StreemInitializer.swift
@@ -28,7 +28,7 @@ class StreemInitializer {
     private let measurementUnits: [UnitLength: String] = [ .inches: "inches", .feet: "feet", .millimeters: "millimeters", .centimeters: "centimeters"]
     
     private init() {
-        Streem.initialize(delegate: self, appId: appId, streemDomain: "sandbox.streem.cloud") { [weak self] in
+        Streem.initialize(delegate: self, appId: appId, streemDomain: streemDomain) { [weak self] in
             guard let self = self else { return }
             self.initialized = true
             Streem.sharedInstance.measurementUnitsToChooseFrom = [ .inches, .feet, .millimeters, .centimeters ]

--- a/StreemNow/StreemInitializer.swift
+++ b/StreemNow/StreemInitializer.swift
@@ -20,6 +20,7 @@ class StreemInitializer {
     private var launchedByInviteId: String?
 
     private let appId = "*** YOUR APP-ID GOES HERE ***"
+    private let streemDomain = "sandbox.streem.cloud"
 
     private let defaultsMeasurementUnitsKey = "measurement_units"
     
@@ -27,7 +28,7 @@ class StreemInitializer {
     private let measurementUnits: [UnitLength: String] = [ .inches: "inches", .feet: "feet", .millimeters: "millimeters", .centimeters: "centimeters"]
     
     private init() {
-        Streem.initialize(delegate: self, appId: appId) { [weak self] in
+        Streem.initialize(delegate: self, appId: appId, streemDomain: "sandbox.streem.cloud") { [weak self] in
             guard let self = self else { return }
             self.initialized = true
             Streem.sharedInstance.measurementUnitsToChooseFrom = [ .inches, .feet, .millimeters, .centimeters ]

--- a/StreemNow/StreemInitializer.swift
+++ b/StreemNow/StreemInitializer.swift
@@ -20,7 +20,7 @@ class StreemInitializer {
     private var launchedByInviteId: String?
 
     private let appId = "*** YOUR APP-ID GOES HERE ***"
-    private let streemDomain = "sandbox.streem.cloud"
+    private let streemDomain = "sandbox.streem.cloud" // for Production, set streemDomain to nil
 
     private let defaultsMeasurementUnitsKey = "measurement_units"
     


### PR DESCRIPTION
## Ticket
https://streempro.atlassian.net/browse/LS-389

## Description
This PR exposes the "domain" parameter of the `Streem.initalize` call.  This is coming about because we had to explain to Lowe's that this field exists.  Given that this app exists as a customer sample, it seems worth making it easier for the user to find.